### PR TITLE
Use `.well-known/openid-credential-issuer`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @digitalbazaar/oid4-client Changelog
 
+## 3.0.0 - 2023-08-dd
+
+### Changed
+- **BREAKING**: The client now uses `.well-known/openid-credential-issuer`
+  instead of `.well-known/oauth-authorization-server` to match the
+  current version of the OID4VCI spec as of this date.
+
 ## 2.0.0 - 2023-06-01
 
 ### Added

--- a/lib/OID4Client.js
+++ b/lib/OID4Client.js
@@ -232,7 +232,7 @@ export class OID4Client {
     try {
       // discover issuer info
       const issuerConfigUrl =
-        `${parsedIssuer.origin}/.well-known/oauth-authorization-server` +
+        `${parsedIssuer.origin}/.well-known/openid-credential-issuer` +
         parsedIssuer.pathname;
       const issuerConfig = await discoverIssuer({issuerConfigUrl, agent});
 


### PR DESCRIPTION
Addresses #9.